### PR TITLE
fix(form): pre-render RichText in server component

### DIFF
--- a/src/components/blocks/form/form.client.tsx
+++ b/src/components/blocks/form/form.client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRef, useState } from 'react';
-import type { ComponentType } from 'react';
+import type { ReactNode } from 'react';
 
 import isEmail from 'validator/lib/isEmail';
 import isMobilePhone from 'validator/lib/isMobilePhone';
@@ -39,14 +39,14 @@ function renderFieldControl(field: PayloadFormsCollection['fields'][number]) {
 }
 
 interface FormClientProps extends PayloadFormsCollection {
-  RichText: ComponentType<{ data?: PayloadFormsCollection['fields'][number]['description'] }>;
+  fieldDescriptions: Record<string, ReactNode>;
 }
 
 export const FormClient = ({
   confirmationMessage,
+  fieldDescriptions,
   fields,
   id,
-  RichText,
   submitButtonLabel,
 }: FormClientProps) => {
   const formRef = useRef<HTMLFormElement>(null);
@@ -177,10 +177,8 @@ export const FormClient = ({
               {field.required ? null : ' (optional)'}
             </FieldLabel>
             <FieldControl render={renderFieldControl(field)} />
-            {field.description ? (
-              <FieldDescription>
-                <RichText data={field.description} />
-              </FieldDescription>
+            {fieldDescriptions[field.name] ? (
+              <FieldDescription>{fieldDescriptions[field.name]}</FieldDescription>
             ) : null}
             <FieldError />
           </Field>

--- a/src/components/blocks/form/index.tsx
+++ b/src/components/blocks/form/index.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 import { FormClient } from '@/components/blocks/form/form.client';
 import type { PayloadFormBlock, PayloadFormsCollection } from '@/payload/payload-types';
@@ -13,6 +13,14 @@ export function FormBlock({ form, RichText }: FormBlockProps) {
     return <p>There was an error rendering the form. Please reload the page and try again.</p>;
   }
 
+  const fieldDescriptions: Record<string, ReactNode> = {};
+
+  for (const field of form.fields) {
+    if (field.description) {
+      fieldDescriptions[field.name] = <RichText data={field.description} />;
+    }
+  }
+
   return (
     <section className="mx-auto my-10 w-full max-w-3xl first:mt-0 last:mb-0">
       {form.formOnly ? null : (
@@ -21,7 +29,7 @@ export function FormBlock({ form, RichText }: FormBlockProps) {
           <RichText data={form.description} />
         </>
       )}
-      <FormClient {...form} RichText={RichText} />
+      <FormClient {...form} fieldDescriptions={fieldDescriptions} />
     </section>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -23,6 +23,12 @@
       "@payload-config": ["./src/payload/payload.config.ts"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

- Fix production build error on `/contact` page caused by passing a `RichText` function component directly to a `'use client'` component (`FormClient`)
- Pre-render field descriptions as `ReactNode` in the server component (`FormBlock`) and pass the serializable result instead
- Also includes tsconfig fix from prior commit

## Test plan

- [ ] Verify `pnpm build` succeeds without prerender errors
- [ ] Verify `/contact` page renders correctly with form field descriptions